### PR TITLE
Fix build problems while compiling dependencies

### DIFF
--- a/02-multiple-containers/Dockerfile
+++ b/02-multiple-containers/Dockerfile
@@ -7,7 +7,7 @@ CMD ["flask", "run", "--host=0.0.0.0"]
 
 RUN apk update \
   && apk add --virtual build-deps gcc python3-dev musl-dev \
-  && apk add postgresql-dev
+  && apk add postgresql-dev build-base
 
 COPY ./api /api
 RUN pip3 install -r /api/requirements.txt


### PR DESCRIPTION
Building a wheel package for greenlet (which in turn is SQLAlchemy dependency) fails due to lack of GCC build-time dependency:
`gcc: error trying to exec 'cc1plus': execvp: No such file or directory`
Adding build-base to system libs solves the problem:
`apk add build-base`

Extras: the article using this gists has no mention of changes to Dockerfile