### PR TITLE
Misspelling in libpq postgresql connection string

### DIFF
--- a/02-multiple-containers/api/api.py
+++ b/02-multiple-containers/api/api.py
@@ -5,7 +5,7 @@ from flask_sqlalchemy import SQLAlchemy
 
 
 app = Flask(__name__)
-app.config['SQLALCHEMY_DATABASE_URI'] = 'postgres://postgres:postgrespassword@postgres_db:5432/postgres'
+app.config['SQLALCHEMY_DATABASE_URI'] = 'postgresql://postgres:postgrespassword@postgres_db:5432/postgres'
 db = SQLAlchemy(app)
 
 


### PR DESCRIPTION
Code throws an error
`sqlalchemy.exc.NoSuchModuleError: Can't load plugin: sqlalchemy.dialects:postgres`
The reason is misspelling in postgres connection string - postgres should be replaced with postgresql, although official documentation states it can be either:
https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING